### PR TITLE
Cleaning up gameplay test mark II

### DIFF
--- a/Assets/Scripts/CombatManager.cs
+++ b/Assets/Scripts/CombatManager.cs
@@ -186,6 +186,7 @@ public class CombatManager : MonoBehaviour
       }
         foreach (GameObject a in sceneManager.overworldSceneGameObjects)
             a.SetActive(true);
+        sceneManager.ChangeGamePhase(GameplayTest.GamePhase.EndTurn);
         sceneManager.UnloadCombatScene();
       // wrap up the scene and transition back to board in the final game.
     }

--- a/Assets/Scripts/SceneGameManager.cs
+++ b/Assets/Scripts/SceneGameManager.cs
@@ -12,11 +12,13 @@ public class SceneGameManager : MonoBehaviour
     public int player2ID;
 
     public List<GameObject> overworldSceneGameObjects;
+    private GameplayTest overworldScene;
 
     void Awake()
     {
         DontDestroyOnLoad(this.gameObject);
         players.AddRange(FindObjectsOfType<EntityPiece>());
+        overworldScene = GameObject.Find("Input Manager").GetComponent<GameplayTest>();
     }
 
     public void LoadCombatScene()
@@ -28,5 +30,11 @@ public class SceneGameManager : MonoBehaviour
     public void UnloadCombatScene()
     {
         SceneManager.UnloadSceneAsync("CombatTest");
+    }
+
+    public void ChangeGamePhase(GameplayTest.GamePhase phase)
+    {
+        overworldScene = GameObject.Find("Input Manager").GetComponent<GameplayTest>();
+        overworldScene.phase = phase;
     }
 }


### PR DESCRIPTION
player can now move after combat ends; overworld scene is hidden when combat scene is loaded into the game